### PR TITLE
Fix selection refresh when rerunning Find Missing References while window is open

### DIFF
--- a/Editor/MissingReferencesResultsWindow.cs
+++ b/Editor/MissingReferencesResultsWindow.cs
@@ -73,15 +73,17 @@ public class MissingReferencesResultsWindow : EditorWindow
             instance = GetWindow<MissingReferencesResultsWindow>("Find Missing References");
         }
 
+        // Prefer current object selection when command is run (even if window is open).
         var selected = Selection.transforms.FirstOrDefault()?.gameObject;
-        if (instance.SelectedGameObject)
+        if (selected && instance.SelectedGameObject != selected)
+        {
+            instance.SelectedGameObject = selected; // Setter trigger refresh
+        }
+        else if (instance.SelectedGameObject)
         {
             instance.refreshMissingReferences();
         }
-        else
-        {
-            instance.SelectedGameObject = selected;
-        }
+
         instance.Show();
     }
 


### PR DESCRIPTION
### Issue
When the Find Missing References window is already open, rerunning
GameObject -> Find Missing References refreshes the previously selected
GameObject instead of the current Unity selection.

### Fix
Prefer the current Selection (if any) before refreshing, and avoid
duplicate refresh calls when the selection changes.

### Testing
- Verified behavior while window is closed and reopened.
- Verified behavior while window is open and selection changes.
- Verified no regression when no GameObject is selected.